### PR TITLE
Add deployment link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ So with this you can mount your own [Graphana](https://grafana.com/) dashboards 
   - Source code: https://sr.ht/~psic4t/atomstr/
   - Demo instance: https://atomstr.data.haus/
 
+## Deployment
+
+We deploy this service using [ansible](https://github.com/planetary-social/ansible-scripts).  The steps for deployment can be read in our [internal notion page](https://www.notion.so/nossocial/Deploying-services-via-Ansible-2b8d01a60d2441e197d4e03d3274c9ef?pvs=4).
+
 
 # Contributing
 


### PR DESCRIPTION
This adds a short link to the larger notion doc